### PR TITLE
Fix native image building

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+spock = "2.3-groovy-3.0"
+publish-plugin = "1.1.0"
+graalvm-gradle-plugin = "0.9.20"
+
+[libraries]
+spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
+graalvm-plugin = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "graalvm-gradle-plugin" }
+
+[plugins]
+publish = { id = "com.gradle.plugin-publish", version.ref = "publish-plugin" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `maven-publish`
     `java-gradle-plugin`
     groovy
-    id("com.gradle.plugin-publish") version "1.1.0"
+    alias(libs.plugins.publish)
 }
 
 group = "com.uwyn.rife2"
@@ -20,7 +20,10 @@ repositories {
 
 dependencies {
     gradleApi()
-    testImplementation("org.spockframework:spock-core:2.3-groovy-3.0")
+    compileOnly(libs.graalvm.plugin) {
+        because("In order to configure it if the user applies it")
+    }
+    testImplementation(libs.spock.core)
     testImplementation(gradleTestKit())
 }
 

--- a/plugin/src/main/java/com/uwyn/rife2/gradle/GraalVMPluginSupport.java
+++ b/plugin/src/main/java/com/uwyn/rife2/gradle/GraalVMPluginSupport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2003-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uwyn.rife2.gradle;
+
+import org.graalvm.buildtools.gradle.dsl.GraalVMExtension;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Sync;
+import org.gradle.api.tasks.TaskProvider;
+
+/**
+ * Configures the GraalVM plugin.
+ * This is done in a separate class so that the types referenced in this
+ * class are not eagerly loaded, which would cause issues with users who
+ * are not using the GraalVM plugin.
+ */
+public abstract class GraalVMPluginSupport {
+
+    public static final String WEBAPP_DIR = "webapp";
+
+    private GraalVMPluginSupport() {
+
+    }
+
+    public static void configureGraalVMPlugin(Project project, Rife2Extension rife2Extension) {
+        GraalVMExtension graalvm = project.getExtensions().findByType(GraalVMExtension.class);
+        TaskProvider<Sync> copyWebApp = project.getTasks().register("copyWebappResources", Sync.class, task -> {
+            task.setDestinationDir(project.getLayout().getBuildDirectory().dir(WEBAPP_DIR).get().getAsFile());
+            task.from(Rife2Plugin.WEBAPP_SRCDIR, copy -> copy.into(WEBAPP_DIR));
+        });
+        graalvm.getBinaries().named("main", options -> {
+            options.getMainClass().convention(rife2Extension.getUberMainClass());
+            options.getClasspath().from(copyWebApp.map(Sync::getDestinationDir));
+            options.getResources().getIncludedPatterns().add("^webapp/.*$");
+        });
+    }
+}

--- a/plugin/src/main/java/com/uwyn/rife2/gradle/Rife2Plugin.java
+++ b/plugin/src/main/java/com/uwyn/rife2/gradle/Rife2Plugin.java
@@ -76,6 +76,7 @@ public class Rife2Plugin implements Plugin<Project> {
         bundlePrecompiledTemplatesIntoJarFile(tasks, precompileTemplates, rife2Extension);
 
         configureMavenPublishing(project, plugins, configurations, uberJarTask);
+        project.getPlugins().withId("org.graalvm.buildtools.native", unused -> GraalVMPluginSupport.configureGraalVMPlugin(project, rife2Extension));
     }
 
     @SuppressWarnings("unchecked")
@@ -116,7 +117,7 @@ public class Rife2Plugin implements Plugin<Project> {
                                                              Rife2Extension rife2Extension) {
         var test_config = configurations.getByName(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME);
         test_config.getDependencies()
-            .add(dependencyHandler.create(project.files(precompileTemplatesTask)));
+                .add(dependencyHandler.create(project.files(precompileTemplatesTask)));
         addServerDependenciesWhenNeeded(project, test_config, dependencyHandler, rife2Extension);
     }
 
@@ -135,7 +136,7 @@ public class Rife2Plugin implements Plugin<Project> {
         rife2Extension.getTemplateDirectories().forEach(dir -> {
             if (dir.getAbsolutePath().contains("src/main/resources/")) {
                 rife2Extension.getPrecompiledTemplateTypes().get().forEach(templateType ->
-                    jar.exclude("/" + dir.getName() + "/**." + templateType.identifier().toLowerCase()));
+                        jar.exclude("/" + dir.getName() + "/**." + templateType.identifier().toLowerCase()));
             }
         });
     }
@@ -151,7 +152,7 @@ public class Rife2Plugin implements Plugin<Project> {
             conf.setCanBeResolved(false);
         });
         rife2DevelopmentOnly.getDependencies().addAllLater(templateDirectories.getElements().map(locations ->
-            locations.stream().map(fs -> dependencyHandler.create(project.files(fs))).collect(Collectors.toList()))
+                locations.stream().map(fs -> dependencyHandler.create(project.files(fs))).collect(Collectors.toList()))
         );
         addServerDependenciesWhenNeeded(project, rife2DevelopmentOnly, dependencyHandler, rife2Extension);
 
@@ -183,12 +184,12 @@ public class Rife2Plugin implements Plugin<Project> {
             jar.into("webapp", spec -> spec.from(WEBAPP_SRCDIR));
             var runtimeClasspath = project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
             jar.from(runtimeClasspath.getElements().map(e -> e.stream()
-                .filter(f -> f.getAsFile().getName().toLowerCase(Locale.ENGLISH).endsWith(".jar"))
-                .map(project::zipTree)
-                .toList()));
+                    .filter(f -> f.getAsFile().getName().toLowerCase(Locale.ENGLISH).endsWith(".jar"))
+                    .map(project::zipTree)
+                    .toList()));
             excludeTemplateSourcesInClassPath(jar, rife2Extension);
             plugins.withId("application", unused -> jar.manifest(manifest ->
-                manifest.getAttributes().put("Main-Class", rife2Extension.getUberMainClass().get()))
+                    manifest.getAttributes().put("Main-Class", rife2Extension.getUberMainClass().get()))
             );
         });
     }
@@ -211,7 +212,7 @@ public class Rife2Plugin implements Plugin<Project> {
         var rife2 = project.getExtensions().create("rife2", Rife2Extension.class);
         rife2.getUseAgent().convention(false);
         rife2.getUberMainClass().convention(project.getExtensions().getByType(JavaApplication.class).getMainClass()
-            .map(mainClass -> mainClass + "Uber"));
+                .map(mainClass -> mainClass + "Uber"));
         DEFAULT_TEMPLATES_DIRS.stream().forEachOrdered(dir -> rife2.getTemplateDirectories().from(project.files(dir)));
         rife2.getIncludeServerDependencies().convention(true);
         return rife2;
@@ -236,7 +237,7 @@ public class Rife2Plugin implements Plugin<Project> {
             conf.setCanBeResolved(true);
             conf.setTransitive(false);
             conf.getDependencies().addLater(rife2Extension.getVersion()
-                .map(version -> dependencyHandler.create(DEPENDENCY_RIFE_PREFIX + version + ":agent")));
+                    .map(version -> dependencyHandler.create(DEPENDENCY_RIFE_PREFIX + version + ":agent")));
         });
     }
 
@@ -249,7 +250,7 @@ public class Rife2Plugin implements Plugin<Project> {
             conf.setCanBeResolved(false);
         });
         config.getDependencies().addLater(rife2Extension.getVersion()
-            .map(version -> dependencyHandler.create(DEPENDENCY_RIFE_PREFIX + version)));
+                .map(version -> dependencyHandler.create(DEPENDENCY_RIFE_PREFIX + version)));
         return config;
     }
 


### PR DESCRIPTION
This commit fixes the native image build, so that:

- the main entry point is the same as the uber jar entry point
- webapp resources are included

This makes the file `resource-config.json` in the hello world project redundant, since this will be automatically configured by this plugin.

The code is designed in such a way that the GraalVM plugin is _optional_ in the user build script.

@gbevin you can test this PR easily on the hello world project, by updating its `settings.gradle.kts` to include the plugin sources:

```kotlin
pluginManagement {
    repositories {
        mavenCentral()
        gradlePluginPortal()
    }
    includeBuild("../rife2-gradle")
}
```

(assuming the `rife2-gradle` directory is a sibling of the `rife2-hello` directory)